### PR TITLE
Merged requirements into a single file

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ So please ensure you have `python 3.8` or greater installed.
 In order to install `OCSysInfo`, you can either download the repository manually via GitHub, and run the `main.py` script located inside of `src` (do also make sure to install the dependencies as shown below), or, via git:
 
 ```sh
+# Clone the repository
 git clone https://github.com/iabtw/OCSysInfo.git
+
+# Switch to the repository folder
 cd OCSysInfo
-# Installing dependencies on Windows
-python3 -m pip install -r requirements-Windows.txt
-# Installing dependencies on Linux
-python3 -m pip install -r requirements-Linux.txt
-# Installing dependencies on macOS
-python3 -m pip install -r requirements-macOS.txt
+
+# Install dependencies
+python3 -m pip install -r requirements.txt
 ```
 
 ## Implementations

--- a/requirements-Linux.txt
+++ b/requirements-Linux.txt
@@ -1,3 +1,0 @@
-requests
-dicttoxml
-distro

--- a/requirements-Windows.txt
+++ b/requirements-Windows.txt
@@ -1,5 +1,0 @@
-requests
-dicttoxml
-distro
-wmi
-pywin32

--- a/requirements-macOS.txt
+++ b/requirements-macOS.txt
@@ -1,4 +1,0 @@
-requests
-dicttoxml
-distro
-pyobjc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+# Cross-platform
+requests; python_version >= '3.8'
+dicttoxml; python_version >= '3.8'
+distro; python_version >= '3.8'
+
+# macOS
+pyobjc; python_version >= '3.8' and sys_platform == 'darwin'
+
+# Windows
+wmi; python_version >= '3.8' and sys_platform == 'win32'
+pywin32; python_version >= '3.8' and sys_platform == 'win32'


### PR DESCRIPTION
- Requirements are split between cross-platform (shared), macOS and Windows in a single `requirements.txt` file
- Requirements also specify the minimum python version
- Removed old `requirements-*.txt` files
- Updated `README.md` accordingly